### PR TITLE
fix: configures i18next to work with the new selector API

### DIFF
--- a/app/src/i18n/i18next.d.ts
+++ b/app/src/i18n/i18next.d.ts
@@ -1,0 +1,14 @@
+import "i18next";
+import type en from "./locales/en.json";
+import type fi from "./locales/fi.json";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    defaultNS: "en";
+    enableSelector: true;
+    resources: {
+      en: typeof en;
+      fi: typeof fi;
+    };
+  }
+}

--- a/app/src/pages/Error/ErrorPage.tsx
+++ b/app/src/pages/Error/ErrorPage.tsx
@@ -19,8 +19,8 @@ const ErrorPage: React.FC = () => {
       aria-label="Error Page"
     >
       <div data-testid="error" className={styles.error}>
-        <h1>{t("Error.Title")}</h1>
-        <p>{message ?? t("Error.General")}</p>
+        <h1>{t(($) => $.Error.Title)}</h1>
+        <p>{message ?? t(($) => $.Error.General)}</p>
       </div>
     </section>
   );

--- a/app/src/pages/Home/HomePage.tsx
+++ b/app/src/pages/Home/HomePage.tsx
@@ -114,7 +114,7 @@ const HomePage = () => {
     if (errorMessage) {
       navigate("/error", {
         state: {
-          message: t(($) => $.Error[errorMessage as keyof typeof $.Error]),
+          message: t(($) => $.Error[errorMessage]),
         },
       });
     }


### PR DESCRIPTION
Hey @Tsingis!

I opened this PR in response to the [discussion](https://github.com/i18next/i18next/discussions/2338) you opened on the i18next repo.

I also translated a few components to make sure it was working correctly.

Looking at the migrations left, I think [this comment](https://github.com/i18next/i18next/pull/2322#issuecomment-3200473124) might be helpful too.

Hope this helps! Feel free to ask additional questions either here, or in the discussions thread.