### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -24,6 +24,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   extract-poetry-version:
+    permissions:
+      contents: read
     uses: ./.github/workflows/poetry-version.yml
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Tsingis/cars-data/security/code-scanning/11](https://github.com/Tsingis/cars-data/security/code-scanning/11)

To address the issue, you should explicitly specify a `permissions` block for the `extract-poetry-version` job that uses the reusable workflow. This block should grant the minimum required privileges for the job to execute successfully. If you are unsure which permissions are needed, it is safest to start with `contents: read`, as this allows code and workflow reading but denies write access. These changes should be made within the `.github/workflows/lambda.yml` file, specifically in the job definition referencing the reusable workflow. No additional methods or external dependencies are needed—just a YAML block addition in the correct place.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
