### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datatest.yml
+++ b/.github/workflows/datatest.yml
@@ -13,6 +13,8 @@ on:
   workflow_dispatch:
 jobs:
   extract-poetry-version:
+    permissions:
+      contents: read
     uses: ./.github/workflows/poetry-version.yml
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Tsingis/cars-data/security/code-scanning/10](https://github.com/Tsingis/cars-data/security/code-scanning/10)

The best fix is to add a `permissions` block with the minimum required privileges to the `extract-poetry-version` job, or at the workflow root to cover jobs missing specific permissions. Since the job uses a reusable workflow, and unless we know that it requires write permissions, it's safest to set to `contents: read`, which is usually sufficient for most jobs that only need to read repo contents. For clarity and maintainability, add:

```yaml
permissions:
  contents: read
```

either after the workflow name or inside the `extract-poetry-version` job definition (but not in both places). Since the reusable workflow might itself specify its own permissions, adding at the job level in the caller workflow remains best practice (so both jobs have a block). In the shown snippet, only the `test` job has permissions—so add it for `extract-poetry-version`. No imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
